### PR TITLE
Pixel系でアプリ終了後もプロセスが残り続けてしまうバグ修正

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
@@ -88,6 +88,9 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
             binder = null;
             connecting = false;
         }
+        // Pixel系の端末で、再生中にアプリが強制終了した場合に、プロセスが残り続けてしまうので、
+        // MusicServiceが強制終了されたタイミングで、プロセスを強制的にキルする #4132
+        android.os.Process.killProcess(android.os.Process.myPid());
     }
 
     /**


### PR DESCRIPTION
# やったこと

- Pixel系の端末でエピソードを再生中に、アプリを強制終了し、再起動すると終了する前の状態が残り続けてしまう問題があった
- onServiceDisconnectedはサービスが予期せず強制終了されたタイミングに呼ばれるコールバックであり、アプリの強制終了と共に呼ばれることを確認したので、こちらのコールバックでアプリのプロセスをキルするようにした。

# 背景

こちらのissueに関連する修正です。
https://github.com/newn-team/standfm/issues/4132

