### PR TITLE
Androidでプレイヤーを一時停止時にスワイプで通知を消せるようにする

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
@@ -158,7 +158,7 @@ public class MusicManager implements OnAudioFocusChangeListener {
             }
         }
 
-        metadata.setActive(true);
+        metadata.setActive(true, false);
     }
 
     public void onPause() {
@@ -174,7 +174,7 @@ public class MusicManager implements OnAudioFocusChangeListener {
         if(wakeLock.isHeld()) wakeLock.release();
         if(wifiLock.isHeld()) wifiLock.release();
 
-        metadata.setActive(true);
+        metadata.setActive(true, true);
     }
 
     public void onStop() {
@@ -186,7 +186,7 @@ public class MusicManager implements OnAudioFocusChangeListener {
 
         abandonFocus();
 
-        metadata.setActive(false);
+        metadata.setActive(false, false);
     }
 
     public void onStateChange(int state) {

--- a/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static android.app.Service.STOP_FOREGROUND_DETACH;
+import static android.media.session.PlaybackState.STATE_PAUSED;
 
 /**
  * @author Guichaguri
@@ -275,7 +276,7 @@ public class MetadataManager {
         pb.setBufferedPosition(playback.getBufferedPosition());
 
         session.setPlaybackState(pb.build());
-        updateNotification();
+        updateNotification(state == STATE_PAUSED);
     }
 
     public void setActive(boolean active, boolean isPaused) {

--- a/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
@@ -31,6 +31,8 @@ import com.guichaguri.trackplayer.service.player.ExoPlayback;
 import java.util.ArrayList;
 import java.util.List;
 
+import static android.app.Service.STOP_FOREGROUND_DETACH;
+
 /**
  * @author Guichaguri
  */
@@ -276,10 +278,10 @@ public class MetadataManager {
         updateNotification();
     }
 
-    public void setActive(boolean active) {
+    public void setActive(boolean active, boolean isPaused) {
         this.session.setActive(active);
 
-        updateNotification();
+        updateNotification(isPaused);
     }
 
     public void destroy() {
@@ -290,6 +292,19 @@ public class MetadataManager {
     }
 
     private void updateNotification() {
+        updateNotification(false);
+    }
+
+    private void updateNotification(boolean isPaused) {
+        if (isPaused) {
+            service.startForeground(1, builder.build());
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                service.stopForeground(STOP_FOREGROUND_DETACH);
+            } else {
+                service.stopForeground(false);
+            }
+            return;
+        }
         if(session.isActive()) {
             service.startForeground(1, builder.build());
         } else {


### PR DESCRIPTION
## 概要

Androidでプレイヤーを一時停止時にスワイプで消せるように対応しました。

## 原因と対応内容

Androidでプレイヤーのコントロール通知を消すためには`service.stopForeground()`というメソッドを使って、フォアグラウンドサービスを停止する必要があるのですが、既存の実装だとonPausedの際にそのメソッドが呼ばれていませんでした。
また、stopForeground()の引数にboolean値を渡すと、foregroundサービスを停止する際に通知を自動で消すかを決めることができるのですが、onPausedの際はfalseを渡すことで自動で通知が破棄されるのを防いでいます。

## 背景

こちらのissueの通りです。
https://github.com/newn-team/standfm/issues/3471
https://github.com/newn-team/standfm/issues/4003