### PR TITLE
一時停止時にサービスがすぐにOSに破棄されてしまう問題の対応

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
@@ -53,8 +53,12 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
             public void onHostDestroy() {
                 reactContext.removeLifecycleEventListener(this);
 
-                // 一時停止中で時間が経過し、クライアントが破棄された際に通知が残り続けてしまうのでここで通知を削除する
-                removeNotification();
+                // 一時停止中で時間が経過し、クライアントが破棄された際に通知が残り続けてしまうので念のためここで通知を削除する
+                NotificationManager nManager = ((NotificationManager) getReactApplicationContext().getSystemService(Context.NOTIFICATION_SERVICE));
+                if (nManager != null) {
+                    nManager.cancel(1);
+                }
+
                 // Pixel系の端末で、再生中にアプリが強制終了した場合に、プロセスが残り続けてしまうので、
                 // MusicServiceが強制終了されたタイミングで、プロセスを強制的にキルする #4132
                 if (getReactApplicationContext() != null) {
@@ -498,14 +502,5 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
     @ReactMethod
     public void getState(final Promise callback) {
         waitForConnection(() -> callback.resolve(binder.getPlayback().getState()));
-    }
-
-    // Pixel系の端末で、再生中にアプリが強制終了した場合に、プロセスが残り続けてしまうので、
-    // MusicServiceが強制終了されたタイミングで、プロセスを強制的にキルする #4132
-    private void removeNotification() {
-        NotificationManager nManager = ((NotificationManager) getReactApplicationContext().getSystemService(Context.NOTIFICATION_SERVICE));
-        if (nManager != null) {
-            nManager.cancel(1);
-        }
     }
 }

--- a/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
@@ -51,15 +51,15 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
 
             @Override
             public void onHostDestroy() {
+                reactContext.removeLifecycleEventListener(this);
+
                 // 一時停止中で時間が経過し、クライアントが破棄された際に通知が残り続けてしまうのでここで通知を削除する
                 removeNotification();
-
                 // Pixel系の端末で、再生中にアプリが強制終了した場合に、プロセスが残り続けてしまうので、
                 // MusicServiceが強制終了されたタイミングで、プロセスを強制的にキルする #4132
                 if (getReactApplicationContext() != null) {
                     android.os.Process.killProcess(android.os.Process.myPid());
                 }
-                reactContext.removeLifecycleEventListener(this);
             }
         });
     }

--- a/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
@@ -52,11 +52,13 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
             @Override
             public void onHostDestroy() {
                 // 一時停止中で時間が経過し、クライアントが破棄された際に通知が残り続けてしまうのでここで通知を削除する
-                NotificationManager nManager = ((NotificationManager) getReactApplicationContext().getSystemService(Context.NOTIFICATION_SERVICE));
-                if (nManager != null) {
-                    nManager.cancel(1);
-                }
                 removeNotification();
+
+                // Pixel系の端末で、再生中にアプリが強制終了した場合に、プロセスが残り続けてしまうので、
+                // MusicServiceが強制終了されたタイミングで、プロセスを強制的にキルする #4132
+                if (getReactApplicationContext() != null) {
+                    android.os.Process.killProcess(android.os.Process.myPid());
+                }
                 reactContext.removeLifecycleEventListener(this);
             }
         });

--- a/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/module/MusicModule.java
@@ -1,9 +1,11 @@
 package com.guichaguri.trackplayer.module;
 
 import android.content.ComponentName;
+import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.ServiceConnection;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.IBinder;
 import android.support.v4.media.RatingCompat;
@@ -114,9 +116,13 @@ public class MusicModule extends ReactContextBaseJavaModule implements ServiceCo
 
         // Binds the service to get a MediaWrapper instance
         Intent intent = new Intent(context, MusicService.class);
-        context.startService(intent);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.startForegroundService(intent);
+        } else {
+            context.startService(intent);
+        }
         intent.setAction(Utils.CONNECT_INTENT);
-        context.bindService(intent, this, 0);
+        context.bindService(intent, this, Context.BIND_AUTO_CREATE);
 
         connecting = true;
     }

--- a/android/src/main/java/com/guichaguri/trackplayer/service/Utils.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/Utils.java
@@ -157,7 +157,7 @@ public class Utils {
             NotificationChannel channel = new NotificationChannel(
                 Utils.NOTIFICATION_CHANNEL,
                 "MusicService",
-                NotificationManager.IMPORTANCE_DEFAULT
+                NotificationManager.IMPORTANCE_LOW
             );
             channel.setShowBadge(false);
             channel.setSound(null, null);

--- a/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
@@ -81,6 +81,8 @@ public class MetadataManager {
 
         // Make it visible in the lockscreen
         builder.setVisibility(NotificationCompat.VISIBILITY_PUBLIC);
+
+        builder.setPriority(NotificationCompat.PRIORITY_LOW);
     }
 
     public MediaSessionCompat getSession() {


### PR DESCRIPTION
https://github.com/newn-team/standfm/issues/4739
の対応

こちらのPRがマージされ次第、standfmのpackage.jsonを更新しようと思います

**対応内容**

- bindService時のフラグが0になっていたのを`Context.BIND_AUTO_CREATE`に指定し、stopForegroundをした後サービスが破棄されないようにした
- デフォルトのプレイヤーの通知の優先順位が高く設定されており、再生されていなくても常に一番上にい続けてしまうので、他の音声再生アプリ（spotifyやYouTubeMusic）などと同じように再生中のみ通知の一番上に表示され、再生していない時は、通知下部に移動するように優先度を設定した
- 念のためではあるが、フォアグラウンドサービスを立ち上げるときはOreoから`startForegroundService()`メソッドを使うように変更になっているので、その修正をした
- #11 にて`onServiceDisconnected`が呼ばれた際にプロセスをキルしていたが、今回の対応によって、アプリを再生中に強制終了しても`onServiceDisconnected`が呼ばれなくなってしまった。したがって、ReactNativeのLifecycleEventListenerを使って、アプリが終了された段階で、プロセスをキルするように修正した

**動作確認内容**
- 確認端末1: Pixel4, OS: 10
- 確認端末2: Pixel2(Emulator), OS: 7.0（Nougat）
- 確認端末3: Pixel3, OS: 11

1. standfmでエピソードを再生する
2. 別の音声再生アプリを立ち上げて、音声を再生する（standfmはバックグラウンド状態）
3. 他にもメモリを食いそうなアプリを複数立ち上げる（YouTubeやinstagramなど）
4. 1分間くらい別のアプリを操作し続ける
5. 通知センターのstand.fmの通知から一時停止中のエピソードを再生する（通知センターの一番下にある）
6. 問題なく音声が途中から再生ができる（通知センターを閉じるとstand.fmの通知が一番上に来る）