### PR TITLE
Androidで音声が勝手に再生されてしまう問題の修正

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicManager.java
@@ -260,6 +260,7 @@ public class MusicManager implements OnAudioFocusChangeListener {
                 permanent = true;
                 abandonFocus();
             case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
+            case AudioManager.AUDIOFOCUS_GAIN:  // 一時的に音声フォーカスが失われたあと、復帰した際に勝手に再生されてしまうため #5146
                 paused = true;
                 break;
             case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK:


### PR DESCRIPTION
### 概要

https://github.com/newn-team/standfm/issues/5146
の対応

### バグの再現方法

1. エピソードを再生し、一時停止する
2. タイマーを設定し、アラーム音を鳴らす
3. アラーム音を止めると、音声が自動で再生される

※2はFacebookのストーリー、LINEの電話の受信後の通知音でも再現確認できています

### バグの原因

Androidの音声フォーカスの変化に伴うハンドリングの仕方が原因でした。
音声フォーカスの変化は、onAudioFocusChangeにて受け取れ、主に以下のイベントが取れます。
- AUDIOFOCUS_LOSS
  - 永続的に音声フォーカスが失われる場合に呼ばれる
  - 音楽アプリとかで再生すると呼ばれる
- AUDIOFOCUS_LOSS_TRANSIENT
  - 一時的に音声フォーカスが失われる場合に呼ばれる
  - アラーム音や電話やLINEのトークの受信音などで呼ばれる
- AUDIOFOCUS_GAIN
  - AUDIOFOCUS_LOSS_TRANSIENTから音声フォーカスが復帰された際に呼ばれる

エピソードを一時停止しているときでも何もしなければ音声フォーカスは保持されている状態なので、アラーム音や着信音などが鳴ると、AUDIOFOCUS_LOSS_TRANSIENT > AUDIOFOCUS_GAINの順で呼ばれ、復帰扱いになってしまいます。また復帰すると、js側でplaybackService.jsで`TrackPlayer.play()`を呼ぶように実装されていたので、自動で再生されるというバグが発生しました。

### 対応方針

- onAudioFocusChangeではjs側に`paused`という一時停止フラグをemitしていますが、これをtrueにすると一時停止状態を保つことができます。
- そこで、以前のstateが「一時停止中」か「再生中」かどうかでこのpausedフラグの値が変わるように修正しました。
  - 以前が再生中：pausedがfalse
  - 以前が一時停止中：pausedがtrue

### 動作確認動画

対応前：
- https://stand-fm.slack.com/archives/C019AVC1PFY/p1609811550026400

対応後：
- https://stand-fm.slack.com/archives/C019AVC1PFY/p1609811984027200