### PR TITLE
Androidでプレイヤー一時停止時に通知がグループ化されたとき、通知アイコンが再生アイコンになってしまう

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
@@ -91,6 +91,9 @@ public class MetadataManager {
         builder.setVisibility(NotificationCompat.VISIBILITY_PUBLIC);
 
         builder.setPriority(NotificationCompat.PRIORITY_LOW);
+
+        // AndroidにてFCM通知がグループ化された際に、通知アイコンがプレイヤーのものが使われてしまうため #5351
+        builder.setGroup("co.newn.standfm.NOTIFICATION_GROUP_PLAYER");
     }
 
     public MediaSessionCompat getSession() {


### PR DESCRIPTION
**概要**
以下のissue対応
https://github.com/newn-team/standfm/issues/5351

**対応内容**
- Androidでは通知が4つ以上貯まると通知がグループ化されるようになっており、そのときにプレイヤーの通知がすでに存在すると、グループ化された際の通知アイコンがプレイヤーのものになってしまっていた。
- FCM通知とプレイヤー通知が同じグループとして認識させないようにするために、プレイヤー側にsetGroupでグループを指定することによって、それぞれの通知が混在した際も別のグループとして扱われるようにした。

**スクリーンショット**

Pixel3(OSVer: 11): 
<img src="https://user-images.githubusercontent.com/15521227/104992141-b9c6ae80-5a63-11eb-9954-0f6a8fcaaef2.png" width="50%"/>

Huawei P10(OSver: 9):
<img src="https://user-images.githubusercontent.com/15521227/104992150-bdf2cc00-5a63-11eb-94fd-4db20309c8ac.jpg" width="50%"/>

