### PR TITLE
IllegalSeekPositionExceptionのクラッシュ対応

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/service/player/ExoPlayback.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/player/ExoPlayback.java
@@ -86,6 +86,14 @@ public abstract class ExoPlayback<T extends Player> implements EventListener, Me
             return;
         }
 
+        // ExoPlayerのqueueのサイズがWindowCountより大きくなってしまう場合があり、
+        // その際に、IllegalSeekPositionExceptionをthrowしてしまうため対応 #2292
+        if (!player.getCurrentTimeline().isEmpty() &&
+                queue.size() > player.getCurrentTimeline().getWindowCount()) {
+            promise.reject("invalid_state", "The queue size is larger than Timeline's window count.");
+            return;
+        }
+
         for(int i = 0; i < queue.size(); i++) {
             if(id.equals(queue.get(i).id)) {
                 lastKnownWindow = player.getCurrentWindowIndex();


### PR DESCRIPTION
https://github.com/newn-team/standfm/issues/2292
の対応

## 原因（半分仮説）

- ExoPlayerのTimelineと呼ばれる再生する音声のキューのようなものがあり、その中のエントリはWindowと呼ばれる（放送の音声ファイルごとにWindowは作られる）
- またRNTrackPlayer側のExoPlaybackというクラスでqueueを別途管理している
- `RNTrackPlayer.skip()` が呼ばれるとTimeline側のキューで保持している音声ファイルをindexで指定して再生位置をオフセットしている
- このindex指定時にTimeline側のキューのサイズとExoPlaybackで管理しているキューのサイズが `ExoPlaybackのqueueSize > TimelineのqueueSize` のような状態になってしまい、存在しないindexを指定してしまうことによりIllegalSeekPositionExceptionが吐かれてしまったと想定される。
- ちなみにIllegalSeekPositionExceptionとは、ExoPlayerにて定義されているエラーであり、指定したindexにwindowが存在しない場合に吐かれるエラーである

## 対応内容

- そもそもなぜ `ExoPlaybackのqueueSize > TimelineのqueueSize` の状態になってしまうのかわからない。おそらくバックグラウンド時の挙動が影響していると思われるが、詳しくは不明。
- 一旦暫定対応という形で `ExoPlaybackのqueueSize > TimelineのqueueSize` の状態になってしまったらreturnするという風に対応することでクラッシュを起きないように対応するようにした
- こちらの5603の対応でエラーになった場合`promise.reject()`を呼び出して、エラーを捕捉する処理を追加している
  - https://github.com/newn-team/standfm/pull/5603