### PR TITLE
rename player channel title

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/service/Utils.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/Utils.java
@@ -164,7 +164,7 @@ public class Utils {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             NotificationChannel channel = new NotificationChannel(
                 Utils.NOTIFICATION_CHANNEL,
-                "MusicService",
+                "プレイヤー通知",
                 NotificationManager.IMPORTANCE_LOW
             );
             channel.setShowBadge(false);


### PR DESCRIPTION
こちらのissueの対応
https://github.com/newn-team/standfm/issues/5534

## 対応内容

通知チャンネルがMusicServiceになっていたので、プレイヤー通知に変更

<img src="https://user-images.githubusercontent.com/15521227/106840137-e1b04600-66e2-11eb-8c26-5fdd44136de3.png" width="50%"/>