### PR TITLE
Call startForeground() onCreate at MusicService

### DIFF
--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
@@ -124,6 +124,7 @@ public class MusicService extends HeadlessJsTaskService {
         super.onDestroy();
 
         destroy();
+        stopForeground(true);
     }
 
     @Override

--- a/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/MusicService.java
@@ -113,6 +113,13 @@ public class MusicService extends HeadlessJsTaskService {
     }
 
     @Override
+    public void onCreate() {
+        super.onCreate();
+        String channel = Utils.getNotificationChannel(this);
+        startForeground(1, new NotificationCompat.Builder(this, channel).build());
+    }
+
+    @Override
     public void onDestroy() {
         super.onDestroy();
 


### PR DESCRIPTION
https://github.com/newn-team/standfm/issues/3232
の対応

### 対応内容

- startForegroundServiceを呼んだあと、startForegroundが呼ばれないと起こるバグのようです。
- このような場合は、startForegroundをServiceのonCreateで呼ぶことで解決するとのことでした。
- クラッシュの再現できていないのですが、こちらの修正を入れてみて一旦経過観察をするという形で対応したいと思います。

### 参考
- https://github.com/react-native-kit/react-native-track-player/pull/1106
- https://stackoverflow.com/questions/50595247/context-startforegroundservice-anr-without-actually-calling-it